### PR TITLE
Remove unnecessary code about runtime parameters, remove breakage caused by use of rabbit_policy:validate/4

### DIFF
--- a/src/pgsql_listen_parameters.erl
+++ b/src/pgsql_listen_parameters.erl
@@ -9,13 +9,9 @@
 
 -module(pgsql_listen_parameters).
 
--behaviour(rabbit_runtime_parameter).
 -behaviour(rabbit_policy_validator).
 
 -export([register/0,
-         notify/4,
-         notify_clear/3,
-         validate/4,
          validate_policy/1]).
 
 -rabbit_boot_step({?MODULE,
@@ -26,29 +22,12 @@
 
 register() ->
   [rabbit_registry:register(Class, Name, ?MODULE) ||
-      {Class, Name} <- [{runtime_parameter, <<"pgsql-listen-host">>},
-                        {runtime_parameter, <<"pgsql-listen-port">>},
-                        {runtime_parameter, <<"pgsql-listen-dbname">>},
-                        {runtime_parameter, <<"pgsql-listen-user">>},
-                        {runtime_parameter, <<"pgsql-listen-password">>},
-                        {policy_validator,  <<"pgsql-listen-host">>},
+      {Class, Name} <- [{policy_validator,  <<"pgsql-listen-host">>},
                         {policy_validator,  <<"pgsql-listen-port">>},
                         {policy_validator,  <<"pgsql-listen-dbname">>},
                         {policy_validator,  <<"pgsql-listen-user">>},
                         {policy_validator,  <<"pgsql-listen-password">>}]],
   ok.
-
-notify(VHost, What, Name, Term) ->
-  rabbit_log:info("notify: ~s,~s,~s,~s~n", [VHost, What, Name, Term]),
-  rabbit_policy:notify(VHost, What, Name, Term).
-
-notify_clear(VHost, What, Name) ->
-  rabbit_log:info("notify_clear: ~s,~s,~s~n", [VHost, What, Name]),
-  rabbit_policy:notify_clear(VHost, What, Name).
-
-validate(VHost, What, Name, Term) ->
-  rabbit_log:info("Validating ~s,~s,~s,~s~n", [VHost, What,Name, Term]),
-  rabbit_policy:validate(VHost, <<"policy">>, Name, Term).
 
 validate_policy(KeyList) ->
   Host     = proplists:get_value(<<"pgsql-listen-host">>, KeyList, none),


### PR DESCRIPTION
As far as I can see, the references to the rabbit_runtime_parameter behaviour in pgsql_listen_parameters are not needed since (according to the README at least) this plugin can be configured by policy, arguments or the config file, but not through parameters. (Which makes perfect sense.)

The code I have removed contains an invocation of rabbit_policy:validate/4. This has changed to a /5 in recent versions of RabbitMQ, which is how I noticed this. Removing it seems like the easiest fix.

Please note: I don't have a postgres server around so I HAVE NOT TESTED THIS. But it compiles at least :-)
